### PR TITLE
fix(BHPF-1): validar criterios de seguridad de contraseña en registro de viajero

### DIFF
--- a/travelhub-web/e2e/auth.spec.ts
+++ b/travelhub-web/e2e/auth.spec.ts
@@ -4,13 +4,13 @@ import { test, expect, Page } from '@playwright/test';
 const REGISTER_USER = {
   nombre: 'Test Playwright Registro',
   email: `test_reg_${crypto.randomUUID()}@example.com`,
-  password: 'TestPass123',
+  password: 'TestPass123!',
 };
 
 const LOGIN_USER = {
   nombre: 'Test Playwright Login',
   email: `test_login_${crypto.randomUUID()}@example.com`,
-  password: 'TestPass123',
+  password: 'TestPass123!',
 };
 
 // =========================================================

--- a/travelhub-web/package-lock.json
+++ b/travelhub-web/package-lock.json
@@ -29,6 +29,7 @@
         "@angular/compiler-cli": "^21.2.0",
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.6.0",
+        "@vitest/coverage-v8": "^4.1.4",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.2",
@@ -972,6 +973,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -4232,32 +4243,63 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4266,7 +4308,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4278,26 +4320,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4305,14 +4347,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4321,9 +4363,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4331,15 +4373,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4505,6 +4547,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -5815,6 +5876,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5886,6 +5957,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6173,6 +6251,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -6748,6 +6855,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8515,6 +8650,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8897,19 +9045,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -8920,8 +9068,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8937,13 +9085,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -8962,6 +9112,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/travelhub-web/package.json
+++ b/travelhub-web/package.json
@@ -32,6 +32,7 @@
     "@angular/compiler-cli": "^21.2.0",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/travelhub-web/src/app/features/auth/login/login.component.html
+++ b/travelhub-web/src/app/features/auth/login/login.component.html
@@ -267,7 +267,7 @@
               [(ngModel)]="registerPassword"
               name="password"
               [type]="showRegisterPassword ? 'text' : 'password'"
-              placeholder="Mín. 6 caracteres"
+              placeholder="Mín. 8 caracteres, mayúscula, número y carácter especial"
               class="input-field"
               autocomplete="new-password"
             />

--- a/travelhub-web/src/app/features/auth/login/login.component.spec.ts
+++ b/travelhub-web/src/app/features/auth/login/login.component.spec.ts
@@ -1,0 +1,174 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../../../core/services/auth.service';
+
+const mockAuthService = {
+  login: () => of({}),
+  register: () => of({ message: 'ok' }),
+};
+
+async function createComponent() {
+  await TestBed.configureTestingModule({
+    imports: [LoginComponent],
+    providers: [
+      { provide: AuthService, useValue: mockAuthService },
+      provideRouter([]),
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(LoginComponent);
+  const component = fixture.componentInstance;
+  fixture.detectChanges();
+  return { fixture, component };
+}
+
+describe('LoginComponent', () => {
+  it('debería crearse correctamente', async () => {
+    const { component } = await createComponent();
+    expect(component).toBeTruthy();
+  });
+
+  describe('onRegister - validación de campos vacíos', () => {
+    it('muestra error si algún campo está vacío', async () => {
+      const { component } = await createComponent();
+      component.onRegister();
+      expect(component.registerError()).toBe('Por favor completa todos los campos.');
+    });
+
+    it('muestra error si falta el correo', async () => {
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerPassword = 'Pass1@seg';
+      component.registerConfirm = 'Pass1@seg';
+      component.onRegister();
+      expect(component.registerError()).toBe('Por favor completa todos los campos.');
+    });
+  });
+
+  describe('onRegister - validación de correo', () => {
+    it('muestra error con correo inválido', async () => {
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerEmail = 'no-es-email';
+      component.registerPassword = 'Pass1@seg';
+      component.registerConfirm = 'Pass1@seg';
+      component.onRegister();
+      expect(component.registerError()).toBe('Ingresa un correo electrónico válido.');
+    });
+  });
+
+  describe('onRegister - validación de contraseña', () => {
+    const baseFields = { registerNombre: 'Juan', registerEmail: 'juan@test.com' };
+
+    it('muestra error si la contraseña tiene menos de 8 caracteres', async () => {
+      const { component } = await createComponent();
+      Object.assign(component, baseFields);
+      component.registerPassword = 'Ab1@';
+      component.registerConfirm = 'Ab1@';
+      component.onRegister();
+      expect(component.registerError()).toContain('mínimo 8 caracteres');
+    });
+
+    it('muestra error si la contraseña no tiene mayúscula', async () => {
+      const { component } = await createComponent();
+      Object.assign(component, baseFields);
+      component.registerPassword = 'password1@';
+      component.registerConfirm = 'password1@';
+      component.onRegister();
+      expect(component.registerError()).toContain('mayúscula');
+    });
+
+    it('muestra error si la contraseña no tiene número', async () => {
+      const { component } = await createComponent();
+      Object.assign(component, baseFields);
+      component.registerPassword = 'Password@abc';
+      component.registerConfirm = 'Password@abc';
+      component.onRegister();
+      expect(component.registerError()).toContain('número');
+    });
+
+    it('muestra error si la contraseña no tiene carácter especial', async () => {
+      const { component } = await createComponent();
+      Object.assign(component, baseFields);
+      component.registerPassword = 'Password123';
+      component.registerConfirm = 'Password123';
+      component.onRegister();
+      expect(component.registerError()).toContain('carácter especial');
+    });
+
+    it('acepta contraseña con todos los requisitos cumplidos', async () => {
+      const { component } = await createComponent();
+      Object.assign(component, baseFields);
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'TestPass1@';
+      component.onRegister();
+      // Si la contraseña es válida, el error de contraseña no se establece
+      const err = component.registerError();
+      expect(err === null || (!err.includes('mayúscula') && !err.includes('mínimo'))).toBe(true);
+    });
+  });
+
+  describe('onRegister - confirmación de contraseña', () => {
+    it('muestra error si las contraseñas no coinciden', async () => {
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerEmail = 'juan@test.com';
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'OtraPass2#';
+      component.onRegister();
+      expect(component.registerError()).toBe('Las contraseñas no coinciden.');
+    });
+  });
+
+  describe('onRegister - flujo completo', () => {
+    it('llama a auth.register con los datos correctos al pasar todas las validaciones', async () => {
+      const registerSpy = vi.spyOn(mockAuthService, 'register').mockReturnValue(of({ message: 'ok' }));
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan Test';
+      component.registerEmail = 'juan@test.com';
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'TestPass1@';
+      component.onRegister();
+      expect(registerSpy).toHaveBeenCalledWith({
+        nombre: 'Juan Test',
+        email: 'juan@test.com',
+        password: 'TestPass1@',
+      });
+    });
+
+    it('muestra mensaje de éxito al registrarse correctamente', async () => {
+      vi.spyOn(mockAuthService, 'register').mockReturnValue(of({ message: 'ok' }));
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerEmail = 'juan@test.com';
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'TestPass1@';
+      component.onRegister();
+      expect(component.registerSuccess()).toBe('¡Cuenta creada! Ahora inicia sesión.');
+    });
+
+    it('muestra error de correo duplicado cuando el backend retorna 400', async () => {
+      vi.spyOn(mockAuthService, 'register').mockReturnValue(throwError(() => ({ status: 400 })));
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerEmail = 'juan@test.com';
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'TestPass1@';
+      component.onRegister();
+      expect(component.registerError()).toBe('Este correo ya está registrado.');
+    });
+
+    it('muestra error genérico ante fallo del servidor', async () => {
+      vi.spyOn(mockAuthService, 'register').mockReturnValue(throwError(() => ({ status: 500 })));
+      const { component } = await createComponent();
+      component.registerNombre = 'Juan';
+      component.registerEmail = 'juan@test.com';
+      component.registerPassword = 'TestPass1@';
+      component.registerConfirm = 'TestPass1@';
+      component.onRegister();
+      expect(component.registerError()).toBe('Error al registrar. Intenta de nuevo.');
+    });
+  });
+});

--- a/travelhub-web/src/app/features/auth/login/login.component.ts
+++ b/travelhub-web/src/app/features/auth/login/login.component.ts
@@ -83,8 +83,11 @@ export class LoginComponent {
       this.registerError.set('Ingresa un correo electrónico válido.');
       return;
     }
-    if (this.registerPassword.length < 6) {
-      this.registerError.set('La contraseña debe tener al menos 6 caracteres.');
+    const passwordRe = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!passwordRe.test(this.registerPassword)) {
+      this.registerError.set(
+        'La contraseña debe tener mínimo 8 caracteres, una mayúscula, un número y un carácter especial.',
+      );
       return;
     }
     if (this.registerPassword !== this.registerConfirm) {


### PR DESCRIPTION
# ¿Qué cambia?
- Reemplaza validación de contraseña de mínimo 6 caracteres por regex que exige: 
  mínimo 8 caracteres, al menos una mayúscula, un número y un carácter especial.
- Actualiza placeholder del campo contraseña para reflejar los nuevos requisitos.
- Agrega pruebas unitarias para el componente de registro (75% cobertura de líneas).
- Actualiza contraseñas en tests e2e de Playwright para cumplir la nueva validación.