### PR TITLE
fix(BHPF-11): guardar hotel en registro de proveedor y validar contraseña segura

### DIFF
--- a/auth-service/adapters/http/auth.py
+++ b/auth-service/adapters/http/auth.py
@@ -5,12 +5,14 @@ from sqlalchemy import create_engine
 import os
 import jwt
 import datetime
+import requests as http_requests
 from werkzeug.security import generate_password_hash, check_password_hash
 
 bp = Blueprint('auth', __name__)
 
 DATABASE_URL = os.getenv('AUTH_DATABASE_URL', 'postgresql://user:password@localhost:5432/travelhub')
 SECRET_KEY = os.getenv('JWT_SECRET', 'supersecretkey')
+CATALOG_SERVICE_URL = os.getenv('CATALOG_SERVICE_URL', 'http://localhost:5001')
 engine = create_engine(DATABASE_URL)
 Session = sessionmaker(bind=engine)
 
@@ -34,6 +36,36 @@ def sign_up():
     )
     session.add(user)
     session.commit()
+
+    hotel_data = data.get('hotel')
+    if data.get('rol', 'user').lower() == 'hotel' and hotel_data:
+        try:
+            hotel_payload = {
+                'admin_id': user.id,
+                'nombre': hotel_data.get('nombre', ''),
+                'descripcion': hotel_data.get('descripcion', ''),
+                'direccion': hotel_data.get('direccion', ''),
+                'ciudad': hotel_data.get('ciudad', ''),
+                'pais': hotel_data.get('pais', ''),
+                'estrellas': hotel_data.get('estrellas', 3),
+                'activo': True,
+            }
+            catalog_resp = http_requests.post(
+                f'{CATALOG_SERVICE_URL}/hotels',
+                json=hotel_payload,
+                timeout=10,
+            )
+            if catalog_resp.status_code not in (200, 201):
+                session.delete(user)
+                session.commit()
+                session.close()
+                return jsonify({'error': 'Error al crear el hotel. Intenta de nuevo.'}), 500
+        except Exception:
+            session.delete(user)
+            session.commit()
+            session.close()
+            return jsonify({'error': 'No se pudo conectar con el servicio de hoteles.'}), 503
+
     session.close()
     return jsonify({'message': 'User created'}), 201
 

--- a/auth-service/requirements.txt
+++ b/auth-service/requirements.txt
@@ -4,6 +4,7 @@ psycopg2-binary
 python-dotenv
 pyjwt
 werkzeug
+requests
 pytest
 pytest-cov
 pytest-flask

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,12 @@ services:
     environment:
       AUTH_DATABASE_URL: postgresql://travelhub_user:travelhub_pass@postgres:5432/travelhub
       JWT_SECRET: mi_secreto_super_seguro_jwt_2024
+      CATALOG_SERVICE_URL: http://catalog-service:5001
     depends_on:
       postgres:
         condition: service_healthy
+      catalog-service:
+        condition: service_started
     networks:
       - travelhub-net
 

--- a/travelhub-hotel/e2e/hotel-auth.spec.ts
+++ b/travelhub-hotel/e2e/hotel-auth.spec.ts
@@ -4,7 +4,7 @@ import { test, expect, Page } from '@playwright/test';
 const REGISTER_USER = {
   nombre: 'Hotel Playwright Registro',
   email: `hotel_reg_${crypto.randomUUID()}@example.com`,
-  password: 'HotelPass123',
+  password: 'HotelPass123!',
   hotelNombre: 'Hotel PW Test Registro',
   ciudad: 'Bogota',
   direccion: 'Calle 123 # 45-67',
@@ -13,7 +13,7 @@ const REGISTER_USER = {
 const LOGIN_USER = {
   nombre: 'Hotel Playwright Login',
   email: `hotel_login_${crypto.randomUUID()}@example.com`,
-  password: 'HotelPass123',
+  password: 'HotelPass123!',
   hotelNombre: 'Hotel PW Test Login',
   ciudad: 'Medellin',
   direccion: 'Carrera 80 # 10-20',
@@ -91,7 +91,7 @@ test.describe.serial('Registro de hotel', () => {
     await page.locator('input[name="nombre"]').fill('Admin');
     await page.locator('input[name="email"]').fill(REGISTER_USER.email);
     await page.locator('input[name="password"]').fill('HotelPass123');
-    await page.locator('input[name="confirmPassword"]').fill('OtraPass456');
+    await page.locator('input[name="confirmPassword"]').fill('OtraPass456!');
     await page.getByRole('button', { name: /Continuar/i }).click();
     await page.waitForTimeout(500);
     await expect(page).not.toHaveURL(/dashboard/);

--- a/travelhub-hotel/package-lock.json
+++ b/travelhub-hotel/package-lock.json
@@ -30,6 +30,7 @@
         "@angular/compiler-cli": "^21.2.0",
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
+        "@vitest/coverage-v8": "^4.1.4",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.2",
@@ -990,6 +991,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -4256,32 +4267,63 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4290,7 +4332,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4302,26 +4344,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4329,14 +4371,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4345,9 +4387,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4355,15 +4397,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4529,6 +4571,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -5861,6 +5922,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5932,6 +6003,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -6219,6 +6297,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -6794,6 +6901,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8577,6 +8712,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8959,19 +9107,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -8982,8 +9130,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8999,13 +9147,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -9024,6 +9174,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/travelhub-hotel/package.json
+++ b/travelhub-hotel/package.json
@@ -33,6 +33,7 @@
     "@angular/compiler-cli": "^21.2.0",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.4",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/travelhub-hotel/src/app/features/auth/register/register.component.html
+++ b/travelhub-hotel/src/app/features/auth/register/register.component.html
@@ -103,7 +103,7 @@
                   [(ngModel)]="password"
                   name="password"
                   [type]="showPassword ? 'text' : 'password'"
-                  placeholder="Mínimo 6 caracteres"
+                  placeholder="Mín. 8 caracteres, mayúscula, número y carácter especial"
                   class="input-field pr-10"
                 />
                 <button
@@ -251,6 +251,20 @@
                 placeholder="contacto@mihotel.com"
                 class="input-field"
               />
+            </div>
+
+            <div>
+              <label class="block text-sm font-medium text-travelGray-700 mb-1.5">
+                Descripción del hotel
+                <span class="text-travelGray-400 font-normal">(opcional)</span>
+              </label>
+              <textarea
+                [(ngModel)]="hotelDescripcion"
+                name="hotelDescripcion"
+                rows="3"
+                placeholder="Describe brevemente tu hotel..."
+                class="input-field resize-none"
+              ></textarea>
             </div>
 
             @if (error()) {

--- a/travelhub-hotel/src/app/features/auth/register/register.component.spec.ts
+++ b/travelhub-hotel/src/app/features/auth/register/register.component.spec.ts
@@ -1,0 +1,202 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { RegisterComponent } from './register.component';
+import { ApiService } from '../../../core/services/api.service';
+import { AuthService } from '../../../core/services/auth.service';
+
+const mockApiService = {
+  post: () => of({ message: 'User created' }),
+};
+
+const mockAuthService = {
+  isLoggedIn: () => false,
+};
+
+async function createComponent() {
+  await TestBed.configureTestingModule({
+    imports: [RegisterComponent],
+    providers: [
+      { provide: ApiService, useValue: mockApiService },
+      { provide: AuthService, useValue: mockAuthService },
+      provideRouter([]),
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(RegisterComponent);
+  const component = fixture.componentInstance;
+  fixture.detectChanges();
+  return { fixture, component };
+}
+
+describe('RegisterComponent', () => {
+  it('debería crearse correctamente', async () => {
+    const { component } = await createComponent();
+    expect(component).toBeTruthy();
+  });
+
+  it('inicia en el paso 1', async () => {
+    const { component } = await createComponent();
+    expect(component.step()).toBe(1);
+  });
+
+  describe('nextStep - validación paso 1', () => {
+    it('muestra error si el nombre está vacío', async () => {
+      const { component } = await createComponent();
+      component.nextStep();
+      expect(component.error()).toBe('El nombre es requerido.');
+    });
+
+    it('muestra error si el correo está vacío', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.nextStep();
+      expect(component.error()).toBe('El correo es requerido.');
+    });
+
+    it('muestra error si la contraseña tiene menos de 8 caracteres', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'Ab1@';
+      component.confirmPassword = 'Ab1@';
+      component.nextStep();
+      expect(component.error()).toContain('mínimo 8 caracteres');
+    });
+
+    it('muestra error si la contraseña no tiene mayúscula', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'hotelpass1@';
+      component.confirmPassword = 'hotelpass1@';
+      component.nextStep();
+      expect(component.error()).toContain('mayúscula');
+    });
+
+    it('muestra error si la contraseña no tiene número', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'HotelPass@abc';
+      component.confirmPassword = 'HotelPass@abc';
+      component.nextStep();
+      expect(component.error()).toContain('número');
+    });
+
+    it('muestra error si la contraseña no tiene carácter especial', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'HotelPass123';
+      component.confirmPassword = 'HotelPass123';
+      component.nextStep();
+      expect(component.error()).toContain('carácter especial');
+    });
+
+    it('muestra error si las contraseñas no coinciden', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'HotelPass1@';
+      component.confirmPassword = 'OtraPass2#';
+      component.nextStep();
+      expect(component.error()).toBe('Las contraseñas no coinciden.');
+    });
+
+    it('avanza al paso 2 con datos válidos', async () => {
+      const { component } = await createComponent();
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'HotelPass1@';
+      component.confirmPassword = 'HotelPass1@';
+      component.nextStep();
+      expect(component.step()).toBe(2);
+      expect(component.error()).toBeNull();
+    });
+  });
+
+  describe('prevStep', () => {
+    it('regresa al paso 1', async () => {
+      const { component } = await createComponent();
+      component.step.set(2);
+      component.prevStep();
+      expect(component.step()).toBe(1);
+    });
+  });
+
+  describe('onRegister - validación paso 2', () => {
+    it('muestra error si el nombre del hotel está vacío', async () => {
+      const { component } = await createComponent();
+      component.onRegister();
+      expect(component.error()).toBe('El nombre del hotel es requerido.');
+    });
+
+    it('muestra error si la ciudad está vacía', async () => {
+      const { component } = await createComponent();
+      component.hotelNombre = 'Mi Hotel';
+      component.onRegister();
+      expect(component.error()).toBe('La ciudad es requerida.');
+    });
+
+    it('muestra error si la dirección está vacía', async () => {
+      const { component } = await createComponent();
+      component.hotelNombre = 'Mi Hotel';
+      component.hotelCiudad = 'Bogotá';
+      component.onRegister();
+      expect(component.error()).toBe('La dirección es requerida.');
+    });
+  });
+
+  describe('onRegister - flujo completo', () => {
+    function fillHotelFields(component: RegisterComponent) {
+      component.nombre = 'Admin Hotel';
+      component.email = 'admin@hotel.com';
+      component.password = 'HotelPass1@';
+      component.hotelNombre = 'Hotel Test';
+      component.hotelCiudad = 'Bogotá';
+      component.hotelDireccion = 'Cra 7 # 10-20';
+    }
+
+    it('llama a api.post con los datos correctos', async () => {
+      const postSpy = vi.spyOn(mockApiService, 'post').mockReturnValue(of({ message: 'ok' }));
+      const { component } = await createComponent();
+      fillHotelFields(component);
+      component.onRegister();
+      expect(postSpy).toHaveBeenCalledWith('/auth/sign-up', expect.objectContaining({
+        nombre: 'Admin Hotel',
+        email: 'admin@hotel.com',
+        rol: 'hotel',
+        hotel: expect.objectContaining({
+          nombre: 'Hotel Test',
+          ciudad: 'Bogotá',
+        }),
+      }));
+    });
+
+    it('muestra éxito al registrarse correctamente', async () => {
+      vi.spyOn(mockApiService, 'post').mockReturnValue(of({ message: 'ok' }));
+      const { component } = await createComponent();
+      fillHotelFields(component);
+      component.onRegister();
+      expect(component.success()).toBe(true);
+    });
+
+    it('muestra error de correo duplicado cuando el backend retorna 409', async () => {
+      vi.spyOn(mockApiService, 'post').mockReturnValue(throwError(() => ({ status: 409 })));
+      const { component } = await createComponent();
+      fillHotelFields(component);
+      component.onRegister();
+      expect(component.error()).toBe('Ya existe una cuenta con ese correo.');
+      expect(component.step()).toBe(1);
+    });
+
+    it('muestra error genérico ante fallo del servidor', async () => {
+      vi.spyOn(mockApiService, 'post').mockReturnValue(throwError(() => ({ status: 500 })));
+      const { component } = await createComponent();
+      fillHotelFields(component);
+      component.onRegister();
+      expect(component.error()).toBe('Error al crear la cuenta. Intenta de nuevo.');
+    });
+  });
+});

--- a/travelhub-hotel/src/app/features/auth/register/register.component.ts
+++ b/travelhub-hotel/src/app/features/auth/register/register.component.ts
@@ -33,6 +33,7 @@ export class RegisterComponent {
   hotelEstrellas = 3;
   hotelTelefono = '';
   hotelEmail = '';
+  hotelDescripcion = '';
 
   paises = [
     'Colombia',
@@ -61,8 +62,11 @@ export class RegisterComponent {
       this.error.set('El correo es requerido.');
       return;
     }
-    if (this.password.length < 6) {
-      this.error.set('La contraseña debe tener al menos 6 caracteres.');
+    const passwordRe = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+    if (!passwordRe.test(this.password)) {
+      this.error.set(
+        'La contraseña debe tener mínimo 8 caracteres, una mayúscula, un número y un carácter especial.',
+      );
       return;
     }
     if (this.password !== this.confirmPassword) {
@@ -105,6 +109,7 @@ export class RegisterComponent {
           pais: this.hotelPais,
           ciudad: this.hotelCiudad.trim(),
           direccion: this.hotelDireccion.trim(),
+          descripcion: this.hotelDescripcion.trim(),
           estrellas: this.hotelEstrellas,
           telefono: this.hotelTelefono.trim(),
           email: this.hotelEmail.trim() || this.email.trim(),


### PR DESCRIPTION
## ¿Qué cambia?
- Corrige el endpoint `/auth/sign-up` del auth-service para llamar al catalog-service 
  y crear el hotel después de crear el usuario, con `admin_id` vinculado.
- Si la creación del hotel falla, hace rollback del usuario para mantener consistencia.
- Agrega campo de descripción del hotel en el formulario de registro (paso 2).
- Reemplaza validación de contraseña de mínimo 6 caracteres por: mínimo 8, 
  una mayúscula, un número y un carácter especial.
- Actualiza contraseñas en tests e2e de Playwright para cumplir la nueva validación.
