### PR TITLE
fix(BHPF-8): Botón cancelar solo visible para reservas confirmadas

### DIFF
--- a/travelhub-web/src/app/features/reservation-detail/reservation-detail.component.html
+++ b/travelhub-web/src/app/features/reservation-detail/reservation-detail.component.html
@@ -155,10 +155,7 @@
           >
             ← Volver al listado
           </a>
-          @if (
-            reservation.estado.toLowerCase() !== 'cancelada' &&
-            reservation.estado.toLowerCase() !== 'completada'
-          ) {
+          @if (reservation.estado.toLowerCase() === 'confirmada') {
             @if (cancelSuccess) {
               <div
                 class="flex-1 text-center bg-green-50 border border-green-200 text-green-700 text-sm font-semibold py-3 rounded-xl"

--- a/travelhub-web/src/app/features/reservations/reservations.component.html
+++ b/travelhub-web/src/app/features/reservations/reservations.component.html
@@ -102,10 +102,7 @@
                   }
                 </div>
                 <div class="flex flex-col gap-2">
-                  @if (
-                    r.estado.toLowerCase() !== 'cancelada' &&
-                    r.estado.toLowerCase() !== 'completada'
-                  ) {
+                  @if (r.estado.toLowerCase() === 'confirmada') {
                     <button
                       type="button"
                       (click)="$event.preventDefault(); $event.stopPropagation(); cancel(r.id)"
@@ -144,12 +141,11 @@
   @if (confirmCancelId !== null) {
     <div
       class="fixed inset-0 bg-black/40 z-40 flex items-center justify-center p-4"
-      role="presentation"
     >
-      <div
-        role="dialog"
+      <dialog
+        open
         aria-modal="true"
-        class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm"
+        class="bg-white rounded-2xl shadow-xl p-6 w-full max-w-sm m-0"
       >
         <div class="text-3xl mb-3 text-center">⚠️</div>
         <h3 class="font-bold text-gray-900 text-center mb-1">
@@ -174,7 +170,7 @@
             {{ 'RESERVATIONS.CONFIRM_BTN' | translate }}
           </button>
         </div>
-      </div>
+      </dialog>
     </div>
   }
 </div>


### PR DESCRIPTION
- Restringe visibilidad del boton 'Cancelar' a estado === 'confirmada' en reservation-detail y reservations (lista)
- Antes usaba doble negacion (!=cancelada && !=completada) que no cumplia el criterio de aceptacion 8.1 de BHPF-8
- Reemplaza div role=presentation y div role=dialog por elementos semanticos nativos (<div> overlay sin rol + <dialog open>) para corregir warnings de accesibilidad